### PR TITLE
Allow alphabetically sorted searches on the Django ORM backend

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -27,7 +27,11 @@ You can enable this type of behavior by defining an ``autocomplete_create`` clas
 Custom Search Field
 ===================
 
-By default, the autocomplete widget will match input against the ``title`` field on your model. If you're using a model that doesn't have a ``title`` attribute, or you just want to search using a different field, you can customize which field it matches against by defining an ``autocomplete_search_field`` property on your model:
+If your model is indexed using the native Wagtail `indexing methods <https://docs.wagtail.io/en/latest/topics/search/indexing.html>`_, then the configured backend will be used to search accross all indexed fields.
+You can narrow the scope by setting the ``autocomplete_search_field`` on the model like in the example to only search one field.
+
+If your model is not indexed then the native Django ORM is used to match input against the ``title`` field on your model.
+If you're using a model that doesn't have a ``title`` attribute, or you just want to search using a different field, you can customize which field it matches against by defining an ``autocomplete_search_field`` property on your model:
 
 .. code-block:: python
 

--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -56,6 +56,12 @@ If you're using a model that doesn't have a ``title`` attribute, or you just wan
         MyModel.objects.filter(my_special_field__icontains='part')
 
     Additionally, this means that ``autocomplete_search_field`` *must* be a model field and cannot be an arbitrary property or method.
+    
+To use a different lookup behaviour on the Django ORM you can specify a tuple with the lookup type on your model's autocomplete_search_field:
+    
+ .. code-block:: python
+ 
+        autocomplete_search_field = ('my_special_field', 'istartswith')
 
 Custom Label Display
 ====================

--- a/wagtailautocomplete/views.py
+++ b/wagtailautocomplete/views.py
@@ -8,8 +8,14 @@ from django.contrib.contenttypes.models import ContentType
 from django.http import (HttpResponseBadRequest, HttpResponseForbidden,
                          JsonResponse)
 from django.views.decorators.http import require_GET, require_POST
-from wagtail.search.backends import get_search_backend
-from wagtail.search.index import Indexed
+from wagtail import VERSION
+
+if VERSION > (2, 0):
+    from wagtail.search.backends import get_search_backend
+    from wagtail.search.index import Indexed
+else:
+    from wagtail.wagtailsearch.backends import get_search_backend
+    from wagtail.wagtailsearch.index import Indexed
 
 
 def render_page(page):


### PR DESCRIPTION
Optionally specify a Django ORM lookup in a tuple with your field name on your model's autocomplete_search_field